### PR TITLE
feat: install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             echo "Navigated to ${1}"
           )
 
+          PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}" \
           curl \
           --proto '=https' \
           --tlsv1.2 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           )"
         env:
           TERM: xterm-256color
+          VERBOSE: true
           PLACEOS_SKIP_INSTALL_OPEN: true
           PLACE_EMAIL: robot@place.tech
           PLACE_PASSWORD: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,49 @@ on:
   push:
   schedule:
     - cron: "0 15 * * 1-5"
+
 jobs:
-  test:
-    name: "${{ !matrix.stable && '🚧 ' || '' }}version: ${{ matrix.version != '' && matrix.version || 'empty'}}, os: ${{ matrix.os }}"
+  test-install:
+    name: "Install: ${{ !matrix.stable && '🚧 ' || '' }}version: ${{ matrix.version != '' && matrix.version || 'empty'}}, os: ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ !matrix.stable }}
+    strategy:
+      fail-fast: false
+      matrix:
+        stable: [true]
+        os:
+          - ubuntu-18.04
+          - ubuntu-20.04
+        include:
+          -
+            os: windows-2022
+            stable: false
+          -
+            os: macos-11
+            stable: false
+    steps:
+      -
+        # Taken from https://github.com/actions/virtual-environments/issues/1143#issuecomment-652264388
+        name: Install Docker Machine on macos
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          mkdir -p ~/.docker/machine/cache
+          curl -sSLo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v20.10.13/boot2docker.iso
+          brew install docker docker-machine docker-compose bash
+          docker-machine create --driver virtualbox default
+          docker-machine env default
+      -
+        name: Install PlaceOS
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 --show-error --location --silent --fail https://raw.githubusercontent.com/place-labs/partner-environment/master/.scripts/install | sh
+        env:
+          PLACEOS_TAG: ${{ matrix.version }}
+          PLACE_EMAIL: robot@place.tech
+          PLACE_PASSWORD: development
+
+  test-start:
+    name: "Start: ${{ !matrix.stable && '🚧 ' || '' }}version: ${{ matrix.version != '' && matrix.version || 'empty'}}, os: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ !matrix.stable }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,11 @@ jobs:
         name: Install PlaceOS
         shell: bash
         run: |
-          PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}"
-          echo $PLACEOS_PARTNER_ENV_BRANCH
-          curl \
-          --proto '=https' \
-          --tlsv1.2 \
-          --show-error \
-          --location \
-          --silent \
-          --fail \
-          https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install | bash
+          PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}" \
+          bash -c "$(
+            curl --proto '=https' --tlsv1.2 -sSfL \
+            https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install
+          )"
         env:
           PLACEOS_SKIP_INSTALL_OPEN: true
           PLACE_EMAIL: robot@place.tech

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,7 @@ jobs:
         os:
           - ubuntu-18.04
           - ubuntu-20.04
-        include:
-          -
-            os: windows-2022
-            stable: false
-          -
-            os: macos-11
-            stable: false
     steps:
-      -
-        # Taken from https://github.com/actions/virtual-environments/issues/1143#issuecomment-652264388
-        name: Install Docker Machine on macos
-        if: ${{ startsWith(matrix.os, 'macos') }}
-        run: |
-          mkdir -p ~/.docker/machine/cache
-          curl -sSLo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v20.10.13/boot2docker.iso
-          brew install docker docker-machine docker-compose bash
-          docker-machine create --driver virtualbox default
-          docker-machine env default
       -
         name: Install PlaceOS
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
         name: Install PlaceOS
         shell: bash
         run: |
-          PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}" \
+          PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}"
+          echo $PLACEOS_PARTNER_ENV_BRANCH
           curl \
           --proto '=https' \
           --tlsv1.2 \
@@ -49,7 +50,6 @@ jobs:
           https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install | bash
         env:
           PLACEOS_SKIP_INSTALL_OPEN: true
-          PLACEOS_TAG: ${{ matrix.version }}
           PLACE_EMAIL: robot@place.tech
           PLACE_PASSWORD: development
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         name: Install PlaceOS
         shell: bash
         run: |
-          PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}" \
+          PLACEOS_PRODUCT_BRANCH="${GITHUB_REF#refs/heads/}" \
           bash -c "$(
             curl --proto '=https' --tlsv1.2 -sSfL \
             https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-install:
-    name: "Install: ${{ !matrix.stable && '🚧 ' || '' }}version: ${{ matrix.version != '' && matrix.version || 'empty'}}, os: ${{ matrix.os }}"
+    name: "Install ${{ !matrix.stable && '🚧 ' || '' }}- os: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ !matrix.stable }}
     strategy:
@@ -38,14 +38,25 @@ jobs:
         name: Install PlaceOS
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 --show-error --location --silent --fail https://raw.githubusercontent.com/place-labs/partner-environment/master/.scripts/install | sh
+          open () (
+            echo "Navigated to ${1}"
+          )
+
+          curl \
+          --proto '=https' \
+          --tlsv1.2 \
+          --show-error \
+          --location \
+          --silent \
+          --fail \
+          https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install | sh
         env:
           PLACEOS_TAG: ${{ matrix.version }}
           PLACE_EMAIL: robot@place.tech
           PLACE_PASSWORD: development
 
   test-start:
-    name: "Start: ${{ !matrix.stable && '🚧 ' || '' }}version: ${{ matrix.version != '' && matrix.version || 'empty'}}, os: ${{ matrix.os }}"
+    name: "Start ${{ !matrix.stable && '🚧 ' || '' }}- version: ${{ matrix.version != '' && matrix.version || 'empty'}}, os: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ !matrix.stable }}
     strategy:
@@ -70,7 +81,7 @@ jobs:
             stable: false
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test initialization
         run: ./placeos start --verbose
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Test initialization
+        if: ${{ matrix.version != '' }} # Testing a set tag
         run: ./placeos start --verbose
         env:
           PLACEOS_TAG: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
         name: Install PlaceOS
         shell: bash
         run: |
-          open () (
-            echo "Navigated to ${1}"
-          )
-
           PLACEOS_PARTNER_ENV_BRANCH="${GITHUB_REF#refs/heads/}" \
           curl \
           --proto '=https' \
@@ -52,6 +48,7 @@ jobs:
           --fail \
           https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install | bash
         env:
+          PLACEOS_SKIP_INSTALL_OPEN: true
           PLACEOS_TAG: ${{ matrix.version }}
           PLACE_EMAIL: robot@place.tech
           PLACE_PASSWORD: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
             https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install
           )"
         env:
+          TERM: xterm-256color
           PLACEOS_SKIP_INSTALL_OPEN: true
           PLACE_EMAIL: robot@place.tech
           PLACE_PASSWORD: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           --location \
           --silent \
           --fail \
-          https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install | sh
+          https://raw.githubusercontent.com/PlaceOS/partner-environment/${{ github.sha }}/scripts/install | bash
         env:
           PLACEOS_TAG: ${{ matrix.version }}
           PLACE_EMAIL: robot@place.tech

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Command:
 ### `$ placeos start`
 
 ```shell-session
-Usage: placeos start [-h|--help]
+Usage: placeos start [-h|--help] [flags...]
 
 Start the PlaceOS environment.
 
@@ -124,10 +124,10 @@ Arguments:
     -h, --help              Display this message.
 ```
 
-### `placeos update`
+### `$ placeos update`
 
 ```
-Usage: placeos update [-h|--help] [VERSION]
+Usage: placeos update [-h|--help] [flags...] [VERSION]
 
 Modifies PLACEOS_TAG to the selected PlaceOS platform version.
 If VERSION is omitted, defaults to the most recent stable version.
@@ -138,10 +138,10 @@ Arguments:
     -h, --help              Display this message.
 ```
 
-### `placeos upgrade`
+### `$ placeos upgrade`
 
 ```
-Usage: placeos upgrade [-h|--help] [VERSION]
+Usage: placeos upgrade [-h|--help] [flags...] [VERSION]
 
 Upgrades the PlaceOS Partner Environment.
 If VERSION is omitted, defaults to the most recent stable version.
@@ -155,7 +155,7 @@ Arguments:
 ### `$ placeos uninstall`
 
 ```shell-session
-Usage: placeos uninstall
+Usage: placeos uninstall [-h|--help] [--force]
 
 Removes PlaceOS containers, removes scripts from paths, and finally deletes the installation path.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ See the [PlaceOS Drivers repository](https://github.com/PlaceOS/drivers) for fur
 
 ### Dependencies
 
-These will need to be installed prior to running `placeos start`:
+These will need to be installed prior to installation:
 
+- [bash >= 4.4.20](https://www.gnu.org/software/bash)
 - [docker >= 18.06.0](https://docs.docker.com/engine/install)
 - [git >= 2.27.0](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ See the [PlaceOS Drivers repository](https://github.com/PlaceOS/drivers) for fur
     --location \
     --show-error --silent \
     --fail \
-    https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | sh
+    https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | bash
   ```
 
 - Via `wget`:
   ```shell-session
-  wget -O - https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | sh
+  wget -O - https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | bash
   ```
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -1,74 +1,85 @@
-<p align="center">
-  <img src="https://github.com/placeos.png?size=200" alt="PlaceOS" />
-</p>
+<img align="right" src="https://github.com/placeos.png?size=200" alt="PlaceOS" />
 
-# Partner Environment
+# PlaceOS Partner Environment
 
-[![CI](https://github.com/place-labs/partner-environment/actions/workflows/ci.yml/badge.svg)](https://github.com/place-labs/partner-environment/actions/workflows/ci.yml)
+[![CI](https://github.com/PlaceOS/partner-environment/actions/workflows/ci.yml/badge.svg)](https://github.com/PlaceOS/partner-environment/actions/workflows/ci.yml)
 
 For use when testing, improving or experimenting with PlaceOS on a local machine.
-Use it for driver, frontend, api and infra development. Treat it as insecure.
+Use it for driver, frontend, api and infrastructure development. **Treat it as insecure**.
 
-When finished dev work for the day, stop the containers with `./placeos stop`
+When finished dev work for the day, stop the containers with `placeos stop`
 
 *NOT* for production use.
 
+## Drivers
+
+See the [PlaceOS Drivers repository](https://github.com/PlaceOS/drivers) for further information.
+
 ## Installation
 
-1. `$ ./placeos start`
-1. Navigate to https://localhost:8443/backoffice
-1. Login with the credentials output by the CLI
+- Via `curl`:
+  ```shell-session
+  curl \
+    --proto '=https' --tlsv1.2 \
+    --location \
+    --show-error --silent \
+    --fail \
+    https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | sh
+  ```
+
+- Via `wget`:
+  ```shell-session
+  wget -O - https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | sh
+  ```
+
+### Dependencies
+
+These will need to be installed prior to running `placeos start`:
+
+- [docker >= 18.06.0](https://docs.docker.com/engine/install)
+- [git >= 2.27.0](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+
+#### Optional tools
+
+- [lazydocker](https://github.com/jesseduffield/lazydocker) for easy docker monitoring.
+- [docker completion](https://docs.docker.com/compose/completion/) for more efficient terminal use.
 
 ### MacOS
 
 If using [Docker Desktop for Mac](https://docs.docker.com/desktop/mac/install/), the default memory allocation of 2GB is insufficient for
-running elasticsearch in addition to the set of PlaceOS services.
+running Elasticsearch in addition to the set of PlaceOS services.
 Bumping the resource limit to 4GB should be sufficient.
 
 ## Configuration
 
-- `PLACE_EMAIL`,`PLACE_PASSWORD`: Create an initial admin user via these environment variables
+- `PLACE_EMAIL`, `PLACE_PASSWORD`: Create an initial admin user via these environment variables
 - `PLACE_DOMAIN`: Set an alternate application domain, defaults to `localhost:8443`
 
 These environment variables can also be passed via the cli.
 
-## Dependencies
-
-These will need to be installed prior to running `./placeos start`:
-
-- [docker](https://www.docker.com/)
-- [docker-compose](https://github.com/docker/compose)
-- [git](https://git-scm.com/)
-
-### Optional tools
-
-- [watchexec](https://github.com/watchexec/watchexec) to run watch scripts (see `scripts/watch-crystal`)
-- [lazydocker](https://github.com/jesseduffield/lazydocker) for easy docker monitoring
-- [docker completion](https://docs.docker.com/compose/completion/) for more efficient terminal use
-
 ## Usage
 
-1. Clone the environment: https://github.com/place-labs/partner-environment.git
-1. Run the install script: `./placeos start` (use this tool to update PlaceOS Version)
+### `$ placeos`
 
 ```shell-session
-Usage: ./placeos [-h|--help] [command]
+Usage: placeos [-h|--help] [command]
 
 Helper script for interfacing with the PlaceOS Partner Environment.
 
 Command:
     start                   Start the environment.
     stop                    Stops the environment.
+    task                    Runs a task in the environment.
     update                  Update the platform version.
     upgrade                 Upgrade the Partner Environment.
-    task                    Runs a task in the environment.
+    uninstall               Uninstalls the Partner Environment.
     help                    Display this message.
 ```
 
-### `$ ./placeos start`
+### `$ placeos start`
 
 ```shell-session
-Usage: ./placeos start [-h|--help]
+Usage: placeos start [-h|--help]
 
 Start the PlaceOS environment.
 
@@ -82,10 +93,10 @@ Arguments:
     -h, --help              Display this message
 ```
 
-### `$ ./placeos stop`
+### `$ placeos stop`
 
 ```shell-session
-Usage: ./placeos stop [-h|--help]
+Usage: placeos stop [-h|--help]
 
 Stop the PlaceOS environment.
 
@@ -94,10 +105,22 @@ Arguments:
     -h, --help              Display this message.
 ```
 
-### `./placeos update`
+### `$ placeos task`
+
+```shell-session
+Usage: placeos task [-h|--help|help] [-t|--task] <task> [help|...] [arguments...]
+
+Run a task in the PlaceOS environment.
+
+Arguments:
+    -t, ---tasks            Display list of available tasks.
+    -h, --help              Display this message.
+```
+
+### `placeos update`
 
 ```
-Usage: ./placeos update [-h|--help] [VERSION]
+Usage: placeos update [-h|--help] [VERSION]
 
 Modifies PLACEOS_TAG to the selected PlaceOS platform version.
 If VERSION is omitted, defaults to the most recent stable version.
@@ -108,35 +131,31 @@ Arguments:
     -h, --help              Display this message.
 ```
 
-### `./placeos upgrade`
+### `placeos upgrade`
 
 ```
-Usage: ./placeos upgrade [-h|--help] [VERSION]
+Usage: placeos upgrade [-h|--help] [VERSION]
 
 Upgrades the PlaceOS Partner Environment.
 If VERSION is omitted, defaults to the most recent stable version.
 
 Arguments:
     --list                  Lists versions of the Partner Environment.
-    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -q, --quiet             Do not write command logs to STDOUT.
     -h, --help              Display this message.
 ```
 
-### `$ ./placeos task`
+### `$ placeos uninstall`
 
 ```shell-session
-Usage: ./placeos task [-h|--help|help] [-t|--task] <task> [help|...] [arguments...]
+Usage: placeos uninstall
 
-Run a task in the PlaceOS environment.
+Removes PlaceOS containers, removes scripts from paths, and finally deletes the installation path.
 
 Arguments:
+    --force                 Skip confirmation of uninstall.
     -h, --help              Display this message.
-    -t, ---tasks            Display list of available tasks.
 ```
-
-## Drivers
-
-See the [PlaceOS Drivers repository](https://github.com/PlaceOS/drivers) for further information.
 
 ## Service Graph
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,34 @@
 
 [![CI](https://github.com/PlaceOS/partner-environment/actions/workflows/ci.yml/badge.svg)](https://github.com/PlaceOS/partner-environment/actions/workflows/ci.yml)
 
-For use when testing, improving or experimenting with PlaceOS on a local machine.
-Use it for driver, frontend, api and infrastructure development. **Treat it as insecure**.
+For use when testing, improving or experimenting with PlaceOS on a local machine.  
+Use it for driver, frontend, api and infrastructure development.
 
-When finished dev work for the day, stop the containers with `placeos stop`
+**Treat it as insecure** as it is *NOT* intended for production use...
 
-*NOT* for production use.
+## Table of Contents
+
+<!-- Generated with `mdtoc --inplace` -->
+<!-- See https://github.com/kubernetes-sigs/mdtoc -->
+<!-- toc -->
+- [PlaceOS Partner Environment](#placeos-partner-environment)
+  - [Table of Contents](#table-of-contents)
+  - [Drivers](#drivers)
+  - [Installation](#installation)
+    - [Dependencies](#dependencies)
+      - [Optional tools](#optional-tools)
+    - [MacOS](#macos)
+  - [Configuration](#configuration)
+  - [Usage](#usage)
+    - [`$ placeos`](#-placeos)
+    - [`$ placeos start`](#-placeos-start)
+    - [`$ placeos stop`](#-placeos-stop)
+    - [`$ placeos task`](#-placeos-task)
+    - [`$ placeos update`](#-placeos-update)
+    - [`$ placeos upgrade`](#-placeos-upgrade)
+    - [`$ placeos uninstall`](#-placeos-uninstall)
+  - [Service Graph](#service-graph)
+<!-- /toc -->
 
 ## Drivers
 
@@ -65,6 +87,8 @@ Bumping the resource limit to 4GB should be sufficient.
 These environment variables can also be passed via the cli.
 
 ## Usage
+
+When finished, stop the environment's containers with `placeos stop`.
 
 ### `$ placeos`
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ See the [PlaceOS Drivers repository](https://github.com/PlaceOS/drivers) for fur
 - Via `curl`:
   ```shell-session
   curl \
-    --proto '=https' --tlsv1.2 \
-    --location \
-    --show-error --silent \
-    --fail \
+    --proto '=https' --tlsv1.2 \ # Enforce strict HTTPS
+    --location \                 # Follow redirects
+    --show-error --silent \      # Show an error message on failure
+    --fail \                     # Fail on HTTP errors
     https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | bash
+  ```
+
+  In other words...
+
+  ```shell-session
+  curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/PlaceOS/partner-environment/master/scripts/install | bash
   ```
 
 - Via `wget`:

--- a/bin/placeos
+++ b/bin/placeos
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+base_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
+"$base_path/placeos" $@

--- a/placeos
+++ b/placeos
@@ -31,16 +31,16 @@ load_environment() {
     if [[ $PLACEOS_TAG =~ ^placeos-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 
         if [[ $PLACEOS_TAG < "placeos-1.2108.2" ]]; then
-            PLACE_STAFF_API_TAG="nightly"
-            PLACE_NGINX_TAG="staff-api"
+            export PLACE_STAFF_API_TAG="nightly"
+            export PLACE_NGINX_TAG="staff-api"
         fi
 
         if [[ $PLACEOS_TAG < "placeos-1.2109.0" ]]; then
-            PLACE_FRONTEND_LOADER_IMAGE="frontends"
+            export PLACE_FRONTEND_LOADER_IMAGE="frontends"
         fi
 
         if [[ $PLACEOS_TAG < "placeos-1.2111.0" ]]; then
-            PLACE_SEARCH_INGEST_IMAGE="rubber-soul"
+            export PLACE_SEARCH_INGEST_IMAGE="rubber-soul"
         fi
     fi
 
@@ -69,7 +69,7 @@ source "${base_path}/scripts/spinner.sh"
 mkdir -p "${base_path}/.logs"
 logfile="${base_path}/.logs/$(date +"%Y%m%d%H%M").log"
 
-COMPOSE_PROJECT_NAME=placeos
+export COMPOSE_PROJECT_NAME=placeos
 
 # Helpers
 ###################################################################################################
@@ -174,7 +174,7 @@ start_environment() (
     email_argument=""
     password_argument=""
     domain_argument=""
-    application_argument=""
+    # application_argument=""
     while [ ${#} -gt 0 ]; do
         command="${1}"
         shift
@@ -202,10 +202,10 @@ start_environment() (
             domain_argument="${1}"
             shift
             ;;
-        --application)
-            application_arguement="${1}"
-            shift
-            ;;
+        # --application)
+        #     application_arguement="${1}"
+        #     shift
+        #     ;;
         --analytics)
             enable_analytics=true
             ;;
@@ -254,11 +254,11 @@ start_environment() (
     fi
 
     if [ -n "${domain_argument}" ]; then
-        PLACE_DOMAIN=${domain_argument}
+        export PLACE_DOMAIN=${domain_argument}
     fi
 
     if [ -n "${application_argument}" ]; then
-        PLACE_APPLICATION=${application_argument}
+        export PLACE_APPLICATION=${application_argument}
     fi
 
     # Attempt to set the username to that in git config if username not in env
@@ -426,6 +426,7 @@ task() (
         exit 0
     fi
 
+    # shellcheck disable=2086
     ./scripts/run-sam-task ${PARAMS}
 )
 

--- a/placeos
+++ b/placeos
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 # shellcheck disable=1003,1090
 
+PRODUCT="PlaceOS Partner Environment"
+
 banner() (
     echo
     echo '░░░░░░░\  ░░\                                ░░░░░░\   ░░░░░░\'
@@ -141,7 +143,7 @@ hard_reset() (
         "Failed to drop Elasticsearch indices."
 
     run_or_abort \
-        'docker-compose restart nginx' \
+        "docker-compose --project-directory='${base_path}' restart nginx" \
         "Restarting nginx..." \
         "Failed to restart nginx." \
         "true"
@@ -151,7 +153,7 @@ start_environment__usage() (
     cat <<EOF
 Usage: ./placeos start [-h|--help]
 
-Start the PlaceOS environment.
+Start the ${PRODUCT}.
 
 Arguments:
     --hard-reset            Reset the environment to a default state.
@@ -315,7 +317,7 @@ start_environment() (
         "Failed to generate secrets."
 
     run_or_abort \
-        "docker-compose ${PROFILES} pull -q" \
+        "docker-compose --project-directory='${base_path}' ${PROFILES} pull -q" \
         "Pulling images..." \
         "Failed to pull images."
 
@@ -327,7 +329,7 @@ start_environment() (
         "Failed to create user entity."
 
     run_or_abort \
-        "docker-compose ${PROFILES} up -d" \
+        "docker-compose --project-directory='${base_path}' ${PROFILES} up -d" \
         "Bringing up services..." \
         "Failed to start services."
 
@@ -350,7 +352,7 @@ stop_environment__usage() (
     cat <<EOF
 Usage: ./placeos stop [-h|--help]
 
-Stop the PlaceOS environment.
+Stop the ${PRODUCT}.
 
 Arguments:
     -v, --verbose           Write logs to STDOUT in addition to the log file.
@@ -377,7 +379,7 @@ stop_environment() (
     done
 
     run_or_abort \
-        "docker-compose down --remove-orphans" \
+        "docker-compose --project-directory='${base_path}' down --remove-orphans" \
         "Tearing down PlaceOS" \
         "Failed to teardown PlaceOS"
 )
@@ -389,7 +391,7 @@ task__usage() (
     cat <<EOF
 Usage: ./placeos task [-h|--help|help] [-t|--task] <task> [help|...] [arguments...]
 
-Run a task in the PlaceOS environment.
+Run a task in the ${PRODUCT}.
 
 Arguments:
     -h, --help              Display this message.
@@ -558,7 +560,7 @@ update_environment() (
 
     if [[ $restart_services == "true" ]]; then
         run_or_abort \
-            "docker-compose restart" \
+            "docker-compose --project-directory='${base_path}' restart" \
             "Restarting services on ${version}..." \
             "Failed to restart services"
     fi
@@ -583,7 +585,7 @@ upgrade_environment__usage() (
     cat <<EOF
 Usage: ./placeos upgrade [-h|--help] [VERSION]
 
-Upgrades the PlaceOS Partner Environment.
+Upgrades the ${PRODUCT}.
 If VERSION is omitted, defaults to the latest version.
 
 Arguments:
@@ -651,15 +653,15 @@ upgrade_environment() (
     else
         run_or_abort \
             "git checkout --quiet $version" \
-            "Upgrading PlaceOS Partner Environment..." \
-            "Failed to upgrade PlaceOS Partner Environment"
+            "Upgrading ${PRODUCT}..." \
+            "Failed to upgrade ${PRODUCT}"
     fi
 
     # Check if it was really updated or not
     if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
-        prompt "PlaceOS Partner Environment is already at $version"
+        prompt "${PRODUCT} is already at $version"
     else
-        prompt "PlaceOS Partner Environment is now at $version"
+        prompt "${PRODUCT} is now at $version"
     fi
 )
 
@@ -712,10 +714,33 @@ uninstall_environment() (
         esac
     fi
 
-    # Stop environment.
-    # Remove PlaceOS containers.
+    # Stop environment and remove containers, volumes, and images.
+    run_or_abort \
+        "docker-compose --project-directory='${base_path}' down --volumes --networks --rmi all" \
+        "Stopping ${PRODUCT}..." \
+        "Failed to stop ${PRODUCT}"
+
     # Remove scripts from paths.
+    run_or_abort \
+        "sed -i '.bak' -E 's/^.*# added by PlaceOS installer$//g' \"${HOME}/.profile\"" \
+        "Removing PlaceOS from $bold.profile$normal..." \
+        "Failed to remove PlaceOS from $bold.profile$normal"
+
     # Delete the installation path.
+    PLACEOS_HOME="${PLACEOS_HOME:-"$HOME/.placeos"}"
+    if [ "${force}" == "false" ]; then
+        read -rp "${PROMPT} $(echo -e "${red}Warning:${reset}") Removing ${bold}${PLACEOS_HOME}${normal}. Would you like to continue (y/n)? " choice
+        case "${choice}" in
+        y | Y | YES | yes) ;;
+
+        *)
+            abort "Exiting."
+            ;;
+        esac
+    fi
+    rm -rf "$PLACEOS_HOME"
+
+    prompt "${green}Uninstalled PlaceOS${reset}"
 )
 
 # Root Command
@@ -725,7 +750,7 @@ usage() (
     cat <<EOF
 Usage: ./placeos [-h|--help] [command]
 
-Helper script for interfacing with the PlaceOS Partner Environment.
+Helper script for interfacing with the ${PRODUCT}.
 
 Command:
     start                   Start the environment.

--- a/placeos
+++ b/placeos
@@ -789,6 +789,9 @@ update)
 upgrade)
     upgrade_environment "$@"
     ;;
+uninstall)
+    uninstall_environment "$@"
+    ;;
 task)
     task "$@"
     ;;

--- a/placeos
+++ b/placeos
@@ -56,16 +56,11 @@ set -euo pipefail
 # Kill child processes on signals
 trap 'tput cnorm; pkill -P $$;' SIGINT SIGTERM
 
-# Colours
-red='\033[0;31m'
-green='\033[0;32m'
-reset='\033[0m'
-
 # Whether to write to STDOUT or not
 VERBOSE="false"
 
 # Path of directory containing the script
-base_path="$(dirname "${0}")"
+base_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 # Terminal spinner
 source "${base_path}/scripts/spinner.sh"
@@ -80,6 +75,14 @@ COMPOSE_PROJECT_NAME=placeos
 ###################################################################################################
 
 PROMPT="░░░"
+
+# Colours
+red='\033[0;31m'
+green='\033[0;32m'
+yellow='\033[0;33m'
+reset='\033[0m'
+bold='\033[1m'
+normal='\033[22m'
 
 unknown_argument() (
     unknown_arg="${1}"
@@ -140,7 +143,8 @@ hard_reset() (
     run_or_abort \
         'docker-compose restart nginx' \
         "Restarting nginx..." \
-        "Failed to restart nginx."
+        "Failed to restart nginx." \
+        "true"
 )
 
 start_environment__usage() (
@@ -227,7 +231,10 @@ start_environment() (
 
     prompt "Starting PlaceOS <${PLACEOS_TAG}>"
 
-    [ $VERBOSE == "false" ] && prompt "For detailed logging, run \`tail -f ${logfile}\`"
+    if [[ $VERBOSE == "false" ]]; then
+        prompt "For detailed logging, run..."
+        prompt "${bold}tail -f ${logfile}${normal}"
+    fi
 
     EMAIL_ENV="${base_path}/.env.email"
 
@@ -312,6 +319,13 @@ start_environment() (
         "Pulling images..." \
         "Failed to pull images."
 
+    [ ${hard_reset} == "true" ] && hard_reset
+
+    run_or_abort \
+        "${base_path}/scripts/run-init-container" \
+        "Initialising PlaceOS with default domain ($PLACE_DOMAIN)..." \
+        "Failed to create user entity."
+
     run_or_abort \
         "docker-compose ${PROFILES} up -d" \
         "Bringing up services..." \
@@ -324,15 +338,9 @@ start_environment() (
             "Failed to configure InfluxDB."
     fi
 
-    [ ${hard_reset} == "true" ] && hard_reset
-
-    run_or_abort \
-        "${base_path}/scripts/run-init-container" \
-        "Initialising PlaceOS with default domain ($PLACE_DOMAIN)..." \
-        "Failed to create user entity."
-
-    prompt "PlaceOS initialised. Login to https://$PLACE_DOMAIN/backoffice/ with..."
-    prompt "$PLACE_EMAIL:$PLACE_PASSWORD"
+    prompt "${green}PlaceOS initialised!${reset}"
+    prompt "Login to https://$PLACE_DOMAIN/backoffice/ with..."
+    prompt "${yellow}$PLACE_EMAIL${reset}:${yellow}$PLACE_PASSWORD${reset}"
 )
 
 # Stop
@@ -492,6 +500,7 @@ If VERSION is omitted, defaults to the most recent stable version.
 
 Arguments:
     --list                  List the available versions.
+    --restart               Restart services after updating, loading the new version.
     -v, --verbose           Write logs to STDOUT in addition to the log file.
     -h, --help              Display this message.
 EOF
@@ -499,6 +508,7 @@ EOF
 
 update_environment() (
     version=""
+    restart_services="false"
     while [ ${#} -gt 0 ]; do
         command="${1}"
         shift
@@ -510,6 +520,9 @@ update_environment() (
         --list)
             fetch_release_tags
             exit 0
+            ;;
+        --restart)
+            restart_services="true"
             ;;
         -v | --verbose)
             VERBOSE="true"
@@ -528,11 +541,11 @@ update_environment() (
     tags=$(fetch_release_tags)
 
     if [[ -z "$version" ]]; then
-        version=$(echo "$tags" | grep -Ev "$VERSION_CHANNEL_REGEX" | head -1)
+        version=$(grep -v --extended-regexp "$VERSION_CHANNEL_REGEX" <<<"${tags}" | head -1)
     fi
 
     # shellcheck disable=2076
-    if [[ -z "$(grep -E "$CALVER_FULL_REGEX|$CALVER_MONTH_REGEX|$VERSION_CHANNEL_REGEX" <<< $version)" ]]; then
+    if ! grep -q --extended-regexp "$CALVER_FULL_REGEX|$CALVER_MONTH_REGEX|$VERSION_CHANNEL_REGEX" <<<"$version"; then
         prompt "Valid versions are...\n\n$tags\n"
         abort "${version} is not a valid version."
     fi
@@ -542,18 +555,25 @@ update_environment() (
         "Updating to ${version}" \
         "Failed to update to ${version}"
 
-    changelog ${version}
+    if [[ $restart_services == "true" ]]; then
+        run_or_abort \
+            "docker-compose restart" \
+            "Restarting services on ${version}..." \
+            "Failed to restart services"
+    fi
+
+    changelog "${version}"
 )
 
 # Upgrade
 ###################################################################################################
 
-PARTNER_ENV_REPO="place-labs/partner-environment"
+PARTNER_ENV_REPO="placeos/partner-environment"
 
 fetch_environment_tags() (
     git ls-remote https://github.com/${PARTNER_ENV_REPO} |
         cut -f2 |
-        grep -E '^refs/tags/|HEAD' |
+        grep --extended-regexp '^refs/tags/|HEAD' |
         cut -d'/' -f3 |
         sort --version-sort --reverse
 )
@@ -567,14 +587,15 @@ If VERSION is omitted, defaults to the latest version.
 
 Arguments:
     --list                  Lists versions of the Partner Environment.
-    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -q, --quiet             Do not write command logs to STDOUT.
     -h, --help              Display this message.
 EOF
 )
 
 upgrade_environment() (
-    version=""
+    version="HEAD"
     tags="$(fetch_environment_tags)"
+    VERBOSE="true"
 
     while [ ${#} -gt 0 ]; do
         command="${1}"
@@ -588,8 +609,8 @@ upgrade_environment() (
             echo "$tags"
             exit 0
             ;;
-        -v | --verbose)
-            VERBOSE="true"
+        -q | --quiet)
+            VERBOSE="false"
             ;;
         -*)
             unknown_argument "${command}" "upgrade_environment__usage"
@@ -603,7 +624,7 @@ upgrade_environment() (
     done
 
     # shellcheck disable=2076
-    if [[ ! " $tags " =~ " $version " ]]; then
+    if [[ ! " $tags " =~ "$version" ]]; then
         prompt "Valid versions are...\n\n$tags\n"
         abort "$version is not a valid version."
     fi
@@ -620,10 +641,18 @@ upgrade_environment() (
 
     last_commit=$(git rev-parse "$version")
 
-    run_or_abort \
-        "git pull --autostash --quiet --rebase origin $version" \
-        "Upgrading PlaceOS Partner Environment..." \
-        "Failed to upgrade PlaceOS Partner Environment"
+    if ! git diff --quiet; then
+        (
+          git stash --include-untracked \
+            && git checkout --quiet "$version" \
+            && git stash apply
+        ) || abort "Failed to upgrade, you may need to resolve merge conflicts"
+    else
+        run_or_abort \
+            "git checkout --quiet $version" \
+            "Upgrading PlaceOS Partner Environment..." \
+            "Failed to upgrade PlaceOS Partner Environment"
+    fi
 
     # Check if it was really updated or not
     if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
@@ -631,6 +660,61 @@ upgrade_environment() (
     else
         prompt "PlaceOS Partner Environment is now at $version"
     fi
+)
+
+# Uninstall
+###################################################################################################
+
+uninstall_environment__usage() (
+    cat <<EOF
+Usage: placeos uninstall
+
+Removes PlaceOS containers, removes scripts from paths, and finally deletes the installation path.
+
+Arguments:
+    --force                 Skip confirmation of uninstall.
+    -h, --help              Display this message.
+EOF
+)
+
+uninstall_environment() (
+    force="false"
+    VERBOSE="true"
+
+    while [ ${#} -gt 0 ]; do
+        command="${1}"
+        shift
+        case ${command} in
+        -h | --help | help)
+            uninstall_environment__usage
+            exit 0
+            ;;
+        --force)
+            force="true"
+            ;;
+        *)
+            unknown_argument "${command}" "uninstall_environment__usage"
+            ;;
+        esac
+    done
+
+    # Get confirmation.
+
+    if [ "${force}" == "false" ]; then
+        read -rp "${PROMPT} $(echo -e "${red}Warning:${reset}") This will remove your PlaceOS installation. Would you like to continue (y/n)? " choice
+        case "${choice}" in
+        y | Y | YES | yes) ;;
+
+        *)
+            abort "Exiting."
+            ;;
+        esac
+    fi
+
+    # Stop environment.
+    # Remove PlaceOS containers.
+    # Remove scripts from paths.
+    # Delete the installation path.
 )
 
 # Root Command
@@ -645,9 +729,10 @@ Helper script for interfacing with the PlaceOS Partner Environment.
 Command:
     start                   Start the environment.
     stop                    Stops the environment.
+    task                    Runs a task in the environment.
     update                  Update the platform version.
     upgrade                 Upgrade the Partner Environment.
-    task                    Runs a task in the environment.
+    uninstall               Uninstalls the Partner Environment.
     help                    Display this message.
 
 Arguments:

--- a/placeos
+++ b/placeos
@@ -174,7 +174,7 @@ start_environment() (
     email_argument=""
     password_argument=""
     domain_argument=""
-    # application_argument=""
+    application_argument=""
     while [ ${#} -gt 0 ]; do
         command="${1}"
         shift
@@ -202,10 +202,10 @@ start_environment() (
             domain_argument="${1}"
             shift
             ;;
-        # --application)
-        #     application_arguement="${1}"
-        #     shift
-        #     ;;
+        --application)
+            application_argument="${1}"
+            shift
+            ;;
         --analytics)
             enable_analytics=true
             ;;

--- a/placeos
+++ b/placeos
@@ -8,7 +8,7 @@ set -euo pipefail
 trap 'tput cnorm; pkill -P $$;' SIGINT SIGTERM
 
 # Name of the environment
-PRODUCT="PlaceOS Partner Environment"
+PLACEOS_PRODUCT="PlaceOS Partner Environment"
 
 # Whether to write to STDOUT or not
 VERBOSE="${VERBOSE:-"false"}"
@@ -154,7 +154,7 @@ start_environment__usage() (
     cat <<EOF
 Usage: ./placeos start [-h|--help]
 
-Start the ${PRODUCT}.
+Start the ${PLACEOS_PRODUCT}.
 
 Arguments:
     --hard-reset            Reset the environment to a default state.
@@ -183,7 +183,7 @@ start_environment() (
         shift
         case ${command} in
         --hard-reset)
-            read -rp "${PROMPT} $(echo -e "${red}Warning:${reset}") This will reset your environment. Would you like to continue (y/n)? " choice
+            read -rp "${PROMPT} $(echo -e "${yellow}Warning:${reset}") This will reset your environment. Would you like to continue (y/n)? " choice
             case "${choice}" in
             y | Y | YES | yes)
                 hard_reset=true
@@ -232,7 +232,7 @@ start_environment() (
 
     load_environment
 
-    prompt "Starting PlaceOS <${PLACEOS_TAG}>"
+    prompt "Starting $PLACEOS_PRODUCT <${PLACEOS_TAG}>"
 
     if [[ $VERBOSE == "false" ]]; then
         prompt "For detailed logging, run..."
@@ -326,7 +326,7 @@ start_environment() (
 
     run_or_abort \
         "${base_path}/scripts/run-init-container" \
-        "Initialising PlaceOS with default domain ($PLACE_DOMAIN)..." \
+        "Initialising $PLACEOS_PRODUCT with default domain ($PLACE_DOMAIN)..." \
         "Failed to create user entity."
 
     run_or_abort \
@@ -341,7 +341,7 @@ start_environment() (
             "Failed to configure InfluxDB."
     fi
 
-    prompt "${green}PlaceOS initialised!${reset}"
+    prompt "${green}$PLACEOS_PRODUCT initialised!${reset}"
     prompt "Login to https://$PLACE_DOMAIN/backoffice/ with..."
     prompt "${yellow}$PLACE_EMAIL${reset}:${yellow}$PLACE_PASSWORD${reset}"
 )
@@ -353,7 +353,7 @@ stop_environment__usage() (
     cat <<EOF
 Usage: ./placeos stop [-h|--help]
 
-Stop the ${PRODUCT}.
+Stop the ${PLACEOS_PRODUCT}.
 
 Arguments:
     -v, --verbose           Write logs to STDOUT in addition to the log file.
@@ -381,8 +381,8 @@ stop_environment() (
 
     run_or_abort \
         "docker-compose --project-directory='${base_path}' down --remove-orphans" \
-        "Tearing down PlaceOS" \
-        "Failed to teardown PlaceOS"
+        "Tearing down $PLACEOS_PRODUCT" \
+        "Failed to teardown $PLACEOS_PRODUCT"
 )
 
 # Task
@@ -392,7 +392,7 @@ task__usage() (
     cat <<EOF
 Usage: ./placeos task [-h|--help|help] [-t|--task] <task> [help|...] [arguments...]
 
-Run a task in the ${PRODUCT}.
+Run a task in the ${PLACEOS_PRODUCT}.
 
 Arguments:
     -h, --help              Display this message.
@@ -586,11 +586,11 @@ upgrade_environment__usage() (
     cat <<EOF
 Usage: ./placeos upgrade [-h|--help] [VERSION]
 
-Upgrades the ${PRODUCT}.
+Upgrades the ${PLACEOS_PRODUCT}.
 If VERSION is omitted, defaults to the latest version.
 
 Arguments:
-    --list                  Lists versions of the ${PRODUCT}.
+    --list                  Lists versions of the ${PLACEOS_PRODUCT}.
     -q, --quiet             Do not write command logs to STDOUT.
     -h, --help              Display this message.
 EOF
@@ -654,15 +654,15 @@ upgrade_environment() (
     else
         run_or_abort \
             "git checkout --quiet $version" \
-            "Upgrading ${PRODUCT}..." \
-            "Failed to upgrade ${PRODUCT}"
+            "Upgrading ${PLACEOS_PRODUCT}..." \
+            "Failed to upgrade ${PLACEOS_PRODUCT}"
     fi
 
     # Check if it was really updated or not
     if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
-        prompt "${PRODUCT} is already at $version"
+        prompt "${PLACEOS_PRODUCT} is already at $version"
     else
-        prompt "${PRODUCT} is now at $version"
+        prompt "${PLACEOS_PRODUCT} is now at $version"
     fi
 )
 
@@ -673,7 +673,7 @@ uninstall_environment__usage() (
     cat <<EOF
 Usage: placeos uninstall
 
-Removes PlaceOS containers, removes scripts from paths, and finally deletes the installation path.
+Removes $PLACEOS_PRODUCT containers, removes scripts from paths, and finally deletes the installation path.
 
 Arguments:
     --force                 Skip confirmation of uninstall.
@@ -705,7 +705,7 @@ uninstall_environment() (
     # Get confirmation.
 
     if [ "${force}" == "false" ]; then
-        read -rp "${PROMPT} $(echo -e "${red}Warning:${reset}") This will remove your PlaceOS installation. Would you like to continue (y/n)? " choice
+        read -rp "${PROMPT} $(echo -e "${yellow}Warning:${reset}") This will remove your $PLACEOS_PRODUCT installation. Would you like to continue (y/n)? " choice
         case "${choice}" in
         y | Y | YES | yes) ;;
 
@@ -718,19 +718,21 @@ uninstall_environment() (
     # Stop environment and remove containers, volumes, and images.
     run_or_abort \
         "docker-compose --project-directory='${base_path}' down --volumes --networks --rmi all" \
-        "Stopping ${PRODUCT}..." \
-        "Failed to stop ${PRODUCT}"
+        "Stopping ${PLACEOS_PRODUCT}..." \
+        "Failed to stop ${PLACEOS_PRODUCT}"
+
+    PROFILE_PATH="${PROFILE_PATH:-"${HOME}/.profile"}"
 
     # Remove scripts from paths.
     run_or_abort \
-        "sed -i '.bak' -E 's/^.*# added by PlaceOS installer$//g' \"${HOME}/.profile\"" \
-        "Removing PlaceOS from $bold.profile$normal..." \
-        "Failed to remove PlaceOS from $bold.profile$normal"
+        "sed -i '.bak' -E 's/^.*# added by PlaceOS installer$//g' \"${PROFILE_PATH}\"" \
+        "Removing $PLACEOS_PRODUCT from ${bold}${PROFILE_PATH}${normal}..." \
+        "Failed to remove $PLACEOS_PRODUCT from ${bold}${PROFILE_PATH}${normal}"
 
     # Delete the installation path.
     PLACEOS_HOME="${PLACEOS_HOME:-"$HOME/.placeos"}"
     if [ "${force}" == "false" ]; then
-        read -rp "${PROMPT} $(echo -e "${red}Warning:${reset}") Removing ${bold}${PLACEOS_HOME}${normal}. Would you like to continue (y/n)? " choice
+        read -rp "${PROMPT} $(echo -e "${yellow}Warning:${reset}") Removing ${bold}${PLACEOS_HOME}${normal}. Would you like to continue (y/n)? " choice
         case "${choice}" in
         y | Y | YES | yes) ;;
 
@@ -741,7 +743,7 @@ uninstall_environment() (
     fi
     rm -rf "$PLACEOS_HOME"
 
-    prompt "${green}Uninstalled PlaceOS${reset}"
+    prompt "${green}Uninstalled $PLACEOS_PRODUCT${reset}"
 )
 
 # Root Command
@@ -751,15 +753,15 @@ usage() (
     cat <<EOF
 Usage: ./placeos [-h|--help] [command]
 
-Helper script for interfacing with the ${PRODUCT}.
+Helper script for interfacing with the ${PLACEOS_PRODUCT}.
 
 Command:
     start                   Start the environment.
     stop                    Stops the environment.
     task                    Runs a task in the environment.
     update                  Update the platform version.
-    upgrade                 Upgrade the ${PRODUCT}.
-    uninstall               Uninstalls the ${PRODUCT}.
+    upgrade                 Upgrade the ${PLACEOS_PRODUCT}.
+    uninstall               Uninstalls the ${PLACEOS_PRODUCT}.
     help                    Display this message.
 
 Arguments:

--- a/placeos
+++ b/placeos
@@ -589,7 +589,7 @@ Upgrades the ${PRODUCT}.
 If VERSION is omitted, defaults to the latest version.
 
 Arguments:
-    --list                  Lists versions of the Partner Environment.
+    --list                  Lists versions of the ${PRODUCT}.
     -q, --quiet             Do not write command logs to STDOUT.
     -h, --help              Display this message.
 EOF
@@ -757,8 +757,8 @@ Command:
     stop                    Stops the environment.
     task                    Runs a task in the environment.
     update                  Update the platform version.
-    upgrade                 Upgrade the Partner Environment.
-    uninstall               Uninstalls the Partner Environment.
+    upgrade                 Upgrade the ${PRODUCT}.
+    uninstall               Uninstalls the ${PRODUCT}.
     help                    Display this message.
 
 Arguments:

--- a/placeos
+++ b/placeos
@@ -1,7 +1,17 @@
 #! /usr/bin/env bash
 # shellcheck disable=1003,1090
 
+# The bash hail mary (exit on failure, unset variables, fail pipe composition early)
+set -euo pipefail
+
+# Kill child processes on signals
+trap 'tput cnorm; pkill -P $$;' SIGINT SIGTERM
+
+# Name of the environment
 PRODUCT="PlaceOS Partner Environment"
+
+# Whether to write to STDOUT or not
+VERBOSE="${VERBOSE:-"false"}"
 
 banner() (
     echo
@@ -51,15 +61,6 @@ load_environment() {
     rm "${ext_env}"
     unset ext_env
 }
-
-# The bash hail mary (exit on failure, unset variables, fail pipe composition early)
-set -euo pipefail
-
-# Kill child processes on signals
-trap 'tput cnorm; pkill -P $$;' SIGINT SIGTERM
-
-# Whether to write to STDOUT or not
-VERBOSE="false"
 
 # Path of directory containing the script
 base_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"

--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -3,13 +3,16 @@
 
 source ./.env.email
 
+# Path of installation directory
+base_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../"
+
 image="placeos/init:${PLACE_INIT_TAG:-nightly}"
 
 docker pull "${image}"
 
 docker run --rm \
     -w /tmp/secrets \
-    -v "${PWD}:/tmp/secrets" \
+    -v "${base_path}:/tmp/secrets" \
     -e PLACE_EMAIL="${PLACE_EMAIL}" \
     -e PLACE_PASSWORD="${PLACE_PASSWORD}" \
     -- "${image}" generate-secrets

--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=1091
 
 source ./.env.email
 

--- a/scripts/init-influxdb
+++ b/scripts/init-influxdb
@@ -9,6 +9,7 @@ influx_key_env=".env.influxdb"
 set -a
 # Attempt to source the InfluxDB API key
 if [ -f ${influx_key_env} ]; then
+    # shellcheck disable=1090
     . ${influx_key_env}
 fi
 set +a
@@ -23,10 +24,10 @@ echo "░░░ Initialising InfluxDB API"
 # Wait for the service to be available
 wait=0
 max_wait=60
-until [ $wait -eq $max_wait ] || docker exec $instance influx ping >/dev/null; do
+until [[ $wait == "$max_wait" ]] || docker exec "$instance" influx ping >/dev/null; do
     sleep $((wait++))
 done
-if [ $wait -eq $max_wait ]; then
+if [[ $wait == "$max_wait" ]]; then
     echo "░░░ Timeout waiting for InfluxDB to be ready"
     exit 1
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-# shellcheck disable=1003,1090
+# shellcheck disable=1003,1090,2016
 
 set -euo pipefail
 
@@ -28,6 +28,12 @@ prompt() (
 abort() (
     prompt "${red}${1}${reset}"
     exit 1
+)
+
+ensure_command() (
+    if ! command -v "$1"&> /dev/null; then
+        abort "$1 not installed on this system."
+    fi
 )
 
 open_url() (
@@ -61,6 +67,10 @@ open_url() (
 
 # 1. Ensures that docker and git are installed
 
+ensure_command 'git'
+ensure_command 'docker'
+ensure_command 'docker-compose'
+
 # 2. Clones the repo into `~/.placeos`, or the PLACEOS_HOME environment variable
 
 case "$OSTYPE" in
@@ -76,6 +86,9 @@ esac
 
 PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
 PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
+
+prompt "Cloning PlaceOS Partner Environment <${PLACEOS_PARTNER_ENV_BRANCH}> into ${PLACEOS_HOME}..."
+
 git clone --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
 
 # 3. Add `~/.placeos/bin` (contains `placeos` command) to PATH
@@ -86,6 +99,7 @@ installer_comment="# added by PlaceOS installer"
 profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\" ${installer_comment}"
 
 if ! grep -q "$installer_comment$" "${PROFILE_PATH}"; then
+    prompt "Adding $PLACEOS_SCRIPTS to \$PATH..."
     echo -e "$profile_path_addition"
     echo -e "$profile_path_addition" >>"${PROFILE_PATH}"
 fi
@@ -94,7 +108,8 @@ source "${PROFILE_PATH}"
 
 # 4. Runs `placeos start`
 
-${PLACEOS_HOME}/placeos start
+prompt 'Running `placeos start`'
+"${PLACEOS_HOME}/placeos" start
 
 # 5. Uses `open_url` to open browser to PlaceOS Backoffice
 

--- a/scripts/install
+++ b/scripts/install
@@ -11,6 +11,8 @@ PROMPT="░░░"
 # Colours
 red='\033[0;31m'
 green='\033[0;32m'
+bold='\033[1m'
+normal='\033[22m'
 reset='\033[0m'
 
 unknown_argument() (
@@ -86,7 +88,7 @@ esac
 PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
 PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
 
-prompt "Cloning PlaceOS Partner Environment <${PLACEOS_PARTNER_ENV_BRANCH}> into ${PLACEOS_HOME}..."
+prompt "Cloning PlaceOS Partner Environment <${PLACEOS_PARTNER_ENV_BRANCH}> into ${bold}${PLACEOS_HOME}${normal}..."
 
 git clone --quiet --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
 
@@ -98,7 +100,7 @@ installer_comment="# added by PlaceOS installer"
 profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\" ${installer_comment}"
 
 if ! grep -q "$installer_comment$" "${PROFILE_PATH}"; then
-    prompt "Adding $PLACEOS_SCRIPTS to \$PATH..."
+    prompt "Adding ${bold}$PLACEOS_SCRIPTS${normal} to \$PATH in ${bold}${PROFILE_PATH}${normal}..."
     echo -e "$profile_path_addition" >>"${PROFILE_PATH}"
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -76,7 +76,7 @@ esac
 
 PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
 PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
-git clone -b "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
+git clone --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
 
 # 3. Add `~/.placeos/bin` (contains `placeos` command) to PATH
 

--- a/scripts/install
+++ b/scripts/install
@@ -72,9 +72,10 @@ case "$OSTYPE" in
 esac
 
 PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
-git clone --depth=1 https://github.com/place-labs/partner-environment "${PLACEOS_HOME}"
+PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
+git clone -b "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
 
-# 3. Add `~/.placeos/.bin` (contains `placeos` command) to PATH
+# 3. Add `~/.placeos/bin` (contains `placeos` command) to PATH
 
 PROFILE_PATH="${HOME}${SEPARATOR}.profile"
 PLACEOS_SCRIPTS="${PLACEOS_HOME}${SEPARATOR}bin"

--- a/scripts/install
+++ b/scripts/install
@@ -6,6 +6,7 @@ set -euo pipefail
 # Helpers
 ###################################################################################################
 
+PRODUCT="PlaceOS Partner Environment"
 PROMPT="░░░"
 
 # Colours
@@ -88,7 +89,7 @@ esac
 PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
 PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
 
-prompt "Cloning PlaceOS Partner Environment <${PLACEOS_PARTNER_ENV_BRANCH}> into ${bold}${PLACEOS_HOME}${normal}..."
+prompt "Cloning ${PRODUCT} <${PLACEOS_PARTNER_ENV_BRANCH}> into ${bold}${PLACEOS_HOME}${normal}..."
 
 git clone --quiet --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
 

--- a/scripts/install
+++ b/scripts/install
@@ -32,25 +32,28 @@ abort() (
 
 open_url() (
     url=${1}
+    PLACEOS_SKIP_INSTALL_OPEN="${PLACEOS_SKIP_INSTALL_OPEN:-"false"}"
 
-    case "$OSTYPE" in
-        darwin*)
-            open "${url}" ;;
-        mysys*)
-            exe /c start "${url/&/^&}" ;;
-        *)
-            if (command -v xdg-open >/dev/null); then
-                xdg-open "${url}"
-            elif (command -v gnome-open >/dev/null); then
-                wslview "${url}"
-            elif (command -v wslview >/dev/null); then
-                wslview "${url}"
-            else
-                echo >&2 "Unsupported platform."
-                return 1
-            fi
-            ;;
-    esac
+    if [[ $PLACEOS_SKIP_INSTALL_OPEN == "false" ]]; then
+        case "$OSTYPE" in
+            darwin*)
+                open "${url}" ;;
+            mysys*)
+                exe /c start "${url/&/^&}" ;;
+            *)
+                if (command -v xdg-open >/dev/null); then
+                    xdg-open "${url}"
+                elif (command -v gnome-open >/dev/null); then
+                    wslview "${url}"
+                elif (command -v wslview >/dev/null); then
+                    wslview "${url}"
+                else
+                    echo >&2 "Unsupported platform."
+                    return 1
+                fi
+                ;;
+        esac
+    fi
 )
 
 # Implementation
@@ -91,7 +94,7 @@ source "${PROFILE_PATH}"
 
 # 4. Runs `placeos start`
 
-placeos start
+${PLACEOS_HOME}/placeos start
 
 # 5. Uses `open_url` to open browser to PlaceOS Backoffice
 

--- a/scripts/install
+++ b/scripts/install
@@ -76,8 +76,8 @@ git clone --depth=1 https://github.com/place-labs/partner-environment "${PLACEOS
 
 # 3. Add `~/.placeos/.bin` (contains `placeos` command) to PATH
 
-PROFILE_PATH="${HOME}${SEPARATOR}profile"
-PLACEOS_SCRIPTS="${PLACEOS_HOME}${SEPARATOR}.bin"
+PROFILE_PATH="${HOME}${SEPARATOR}.profile"
+PLACEOS_SCRIPTS="${PLACEOS_HOME}${SEPARATOR}bin"
 installer_comment="# added by PlaceOS installer"
 profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\" ${installer_comment}"
 

--- a/scripts/install
+++ b/scripts/install
@@ -54,8 +54,7 @@ open_url() (
                 elif (command -v wslview >/dev/null); then
                     wslview "${url}"
                 else
-                    echo >&2 "Unsupported platform."
-                    return 1
+                    abort "Unsupported platform."
                 fi
                 ;;
         esac
@@ -89,7 +88,7 @@ PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
 
 prompt "Cloning PlaceOS Partner Environment <${PLACEOS_PARTNER_ENV_BRANCH}> into ${PLACEOS_HOME}..."
 
-git clone --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
+git clone --quiet --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
 
 # 3. Add `~/.placeos/bin` (contains `placeos` command) to PATH
 
@@ -100,7 +99,6 @@ profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\"
 
 if ! grep -q "$installer_comment$" "${PROFILE_PATH}"; then
     prompt "Adding $PLACEOS_SCRIPTS to \$PATH..."
-    echo -e "$profile_path_addition"
     echo -e "$profile_path_addition" >>"${PROFILE_PATH}"
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -3,10 +3,31 @@
 
 set -euo pipefail
 
+# Configuration
+###################################################################################################
+
+case "$OSTYPE" in
+    mysys*)
+        SEPARATOR='\'
+        PATH_SEPERATOR=';'
+        ;;
+    *)
+        SEPARATOR='/'
+        PATH_SEPERATOR=':'
+        ;;
+esac
+
+PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
+PLACEOS_SCRIPTS="${PLACEOS_HOME}${SEPARATOR}bin"
+PROFILE_PATH="${HOME}${SEPARATOR}.profile"
+
+PLACEOS_PRODUCT="PlaceOS Partner Environment"
+PLACEOS_PRODUCT_BRANCH=${PLACEOS_PRODUCT_BRANCH:-"master"}
+PLACEOS_PRODUCT_REPO="https://github.com/PlaceOS/partner-environment"
+
 # Helpers
 ###################################################################################################
 
-PRODUCT="PlaceOS Partner Environment"
 PROMPT="░░░"
 
 # Colours
@@ -75,28 +96,12 @@ ensure_command 'docker-compose'
 
 # 2. Clones the repo into `~/.placeos`, or the PLACEOS_HOME environment variable
 
-case "$OSTYPE" in
-    mysys*)
-        SEPARATOR='\'
-        PATH_SEPERATOR=';'
-        ;;
-    *)
-        SEPARATOR='/'
-        PATH_SEPERATOR=':'
-        ;;
-esac
+prompt "Cloning ${PLACEOS_PRODUCT} <${PLACEOS_PRODUCT_BRANCH}> into ${bold}${PLACEOS_HOME}${normal}..."
 
-PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
-PLACEOS_PARTNER_ENV_BRANCH=${PLACEOS_PARTNER_ENV_BRANCH:-"master"}
-
-prompt "Cloning ${PRODUCT} <${PLACEOS_PARTNER_ENV_BRANCH}> into ${bold}${PLACEOS_HOME}${normal}..."
-
-git clone --quiet --branch "${PLACEOS_PARTNER_ENV_BRANCH}" --depth=1 https://github.com/PlaceOS/partner-environment "${PLACEOS_HOME}"
+git clone --quiet --branch "${PLACEOS_PRODUCT_BRANCH}" --depth=1 "${PLACEOS_PRODUCT_REPO}" "${PLACEOS_HOME}"
 
 # 3. Add `~/.placeos/bin` (contains `placeos` command) to PATH
 
-PROFILE_PATH="${HOME}${SEPARATOR}.profile"
-PLACEOS_SCRIPTS="${PLACEOS_HOME}${SEPARATOR}bin"
 installer_comment="# added by PlaceOS installer"
 profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\" ${installer_comment}"
 
@@ -116,4 +121,4 @@ prompt 'Running `placeos start`'
 
 open_url "https://localhost:8443/backoffice"
 
-prompt "${green}Installed PlaceOS.${reset}"
+prompt "${green}Installed $PLACEOS_PRODUCT.${reset}"

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,97 @@
+#! /usr/bin/env bash
+# shellcheck disable=1003,1090
+
+set -euo pipefail
+
+# Helpers
+###################################################################################################
+
+PROMPT="░░░"
+
+# Colours
+red='\033[0;31m'
+green='\033[0;32m'
+reset='\033[0m'
+
+unknown_argument() (
+    unknown_arg="${1}"
+    usage="${2}"
+    [ -n "${unknown_arg}" ] && prompt "${red}Unknown option:${reset} ${unknown_arg}"
+    eval "${usage}"
+    exit 1
+)
+
+prompt() (
+    echo -e "${PROMPT} ${1}"
+)
+
+abort() (
+    prompt "${red}${1}${reset}"
+    exit 1
+)
+
+open_url() (
+    url=${1}
+
+    case "$OSTYPE" in
+        darwin*)
+            open "${url}" ;;
+        mysys*)
+            exe /c start "${url/&/^&}" ;;
+        *)
+            if (command -v xdg-open >/dev/null); then
+                xdg-open "${url}"
+            elif (command -v gnome-open >/dev/null); then
+                wslview "${url}"
+            elif (command -v wslview >/dev/null); then
+                wslview "${url}"
+            else
+                echo >&2 "Unsupported platform."
+                return 1
+            fi
+            ;;
+    esac
+)
+
+# Implementation
+####################################################################################################
+
+# 1. Ensures that docker and git are installed
+
+# 2. Clones the repo into `~/.placeos`, or the PLACEOS_HOME environment variable
+
+case "$OSTYPE" in
+    mysys*)
+        SEPARATOR='\'
+        PATH_SEPERATOR=';'
+        ;;
+    *)
+        SEPARATOR='/'
+        PATH_SEPERATOR=':'
+        ;;
+esac
+
+PLACEOS_HOME=${PLACEOS_HOME:-"${HOME}${SEPARATOR}.placeos"}
+git clone --depth=1 https://github.com/place-labs/partner-environment "${PLACEOS_HOME}"
+
+# 3. Add `~/.placeos/.bin` (contains `placeos` command) to PATH
+
+PROFILE_PATH="${HOME}${SEPARATOR}profile"
+PLACEOS_SCRIPTS="${PLACEOS_HOME}${SEPARATOR}.bin"
+installer_comment="# added by PlaceOS installer"
+profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\" ${installer_comment}"
+
+if ! grep -q "$installer_comment$" "${PROFILE_PATH}"; then
+    export PATH="${PLACEOS_SCRIPTS}${PATH_SEPERATOR}${PATH}"
+    echo -e "$profile_path_addition" >>"${PROFILE_PATH}"
+fi
+
+# 4. Runs `placeos start`
+
+placeos start
+
+# 5. Uses `open_url` to open browser to PlaceOS Backoffice
+
+open_url "https://localhost:8443/backoffice"
+
+prompt "${green}Installed PlaceOS.${reset}"

--- a/scripts/install
+++ b/scripts/install
@@ -82,9 +82,11 @@ installer_comment="# added by PlaceOS installer"
 profile_path_addition="export PATH=\"${PLACEOS_SCRIPTS}${PATH_SEPERATOR}\$PATH\" ${installer_comment}"
 
 if ! grep -q "$installer_comment$" "${PROFILE_PATH}"; then
-    export PATH="${PLACEOS_SCRIPTS}${PATH_SEPERATOR}${PATH}"
+    echo -e "$profile_path_addition"
     echo -e "$profile_path_addition" >>"${PROFILE_PATH}"
 fi
+
+source "${PROFILE_PATH}"
 
 # 4. Runs `placeos start`
 

--- a/scripts/run-init-container
+++ b/scripts/run-init-container
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE_PROJECT_NAME=placeos docker-compose run --rm --no-deps init start
+COMPOSE_PROJECT_NAME=placeos docker-compose run --rm init start

--- a/scripts/run-init-container
+++ b/scripts/run-init-container
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE_PROJECT_NAME=placeos docker-compose run --rm init start
+# Path of installation directory
+base_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../"
+
+COMPOSE_PROJECT_NAME=placeos \
+    docker-compose \
+        --project-directory="$base_path" \
+        run --rm init start

--- a/scripts/run-sam-task
+++ b/scripts/run-sam-task
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE_PROJECT_NAME=placeos docker-compose run --rm --no-deps init task "$@"
+COMPOSE_PROJECT_NAME=placeos docker-compose run --rm init task "$@"

--- a/scripts/run-sam-task
+++ b/scripts/run-sam-task
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE_PROJECT_NAME=placeos docker-compose run --rm init task "$@"
+# Path of installation directory
+base_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../"
+
+COMPOSE_PROJECT_NAME=placeos \
+    docker-compose \
+        --project-directory="$base_path" \
+        run --rm init task "$@"

--- a/scripts/spinner.sh
+++ b/scripts/spinner.sh
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+# shellcheck disable=1000-9999
+#
 # MIT License
 # Copyright (c) 2021 Tasos Latsas
 #

--- a/scripts/watch-crystal
+++ b/scripts/watch-crystal
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-
-# shellcheck disable=2068
-watchexec -c -r -w src -w spec -- "$DIR/crystal-spec" $@

--- a/scripts/watch-crystal
+++ b/scripts/watch-crystal
@@ -1,3 +1,6 @@
-#!/usr/bin/env bash
+#! /usr/bin/env bash
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# shellcheck disable=2068
 watchexec -c -r -w src -w spec -- "$DIR/crystal-spec" $@


### PR DESCRIPTION
**Description of the change**

See the updated [README](https://github.com/PlaceOS/partner-environment/blob/feat/install/README.md).

- Simplifies the installation of the partner environment via curling `scripts/install`
- Installs to `$HOME/.placeos` and adds `placeos` script to the path
- Resolves a bug where init would create the wrong admin user
- Resolves a bug where the application was not set via argument to `placeos start`
- Adds `placeos uninstall` script to destructively remove the environment (can probably be a separate PR)
- Makes all scripts independent of where they're called from
- ~~Adds experimental CI targets for MacOS and Windows~~

**Applicable issues**

- Closes https://github.com/PlaceOS/PlaceOS/issues/71
